### PR TITLE
[RC 3.0.0] Support more flexible wait_for searching

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,7 @@ import shutil
 
 import pytest
 
+from webdriver_recorder.browser import XPathWithSubstringLocator
 from webdriver_recorder.plugin import lettergen
 
 # Enables testing failure cases in plugin logic by dynamically generating
@@ -122,8 +123,8 @@ def test_happy_remote_chrome(remote_chrome):
 
 # The underscore here keeps pytest from executing this as a test itself.
 def _test_happy_case(browser):
-    browser.wait_for('button', 'update')
+    browser.wait_for(XPathWithSubstringLocator(tag='button', displayed_substring='update'))
     browser.send_inputs('boundless')
-    browser.click('button', 'update')
-    browser.wait_for('p', 'boundless')
+    browser.click_button('update')
+    browser.wait_for(XPathWithSubstringLocator(tag='p', displayed_substring='boundless'))
     assert len(browser.pngs) == 3

--- a/webdriver_recorder/plugin.py
+++ b/webdriver_recorder/plugin.py
@@ -2,13 +2,13 @@ import datetime
 import html
 import itertools
 import json
+import logging
 import os
 import re
 import tempfile
-import warnings
+from pathlib import Path
 from string import ascii_uppercase
 from typing import List, Any, Dict, Optional, Callable
-from pathlib import Path
 
 import jinja2
 import pytest
@@ -18,6 +18,8 @@ from . import browser as browser_
 
 TEMPLATE_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                              'report.template.html')
+
+log = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser):
@@ -95,7 +97,7 @@ def browser(chrome):
 @pytest.fixture(scope='session')
 def chrome():
     if 'CHROME_BIN' not in os.environ:
-        warnings.warn('Environment variable CHROME_BIN undefined. Using system default for Chrome.')
+        log.info('Environment variable CHROME_BIN undefined. Using system default for Chrome.')
     with browser_.Chrome() as browser:
         yield browser
 


### PR DESCRIPTION
# Release Candidate, Major Version Upgrade
This introduces backwards-incompatible (i.e., breaking) changes, so will bump our version to 3.0.0. 

The existing xpath-with-substring-only means of searching documents is limiting and requires us to depend on specific text being displayed, instead of encouraging sensible class or id names for elements that can be searched independently of the presentation copy.

V3.0 will afford more flexibility to callers, allowing for better, more intuitive testing. 

---

Before tagging this release, we should pin existing dependents to `webdriver-recorder=<3.0`pending their update to the new parameter requirements. There is no rush for this, it's a quality-of-life improvement and is not blocking anything.

---


# Change Summary

Non-breaking changes:

- Adds a `SearchMethod` enum that proxies Selenium's `By` class, so that we have typed access to those fields.
- Adds a `Locator` data class that supports creating and reusing document search methods (that are supported by selenium)
- Updates test to work with new functionality, and adds new tests
- Fixes bug where 'click_button' would not actually click a button
- Uses logging instead of 'warnings', and demotes the CHROME_BIN message to 'info' instead of 'warning'

Breaking Changes:

The signatures for the following `Browser` methods have changed: `wait`, `wait_for`, `click`.

- Instead of accepting `tag` and `substring` directly, they now accept a `Locator`. This allows callers to define what methods they want to use (instead of requiring xpath with substring); those who want to keep existing behavior need to update their calls from:

```
# OLD, BROKEN
browser.wait_for('div', 'some text')

# to... NEW, WORKING:
browser.wait_for(XPathWithSubstringLocator(tag='div', displayed_substring='some text')
```

- `wait` and `wait_for` now _return_ the element they are waiting for, allowing callers to interact with the elements they've so long wanted to see.

Example:

```
button = browser.wait_for(Locator(search_method=SearchMethod.CSS_SELECTOR, search_value='button.submit-button')
button.click()
```