### PR TITLE
Supports extra fixtures for easier configuration for dependents

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,32 +1,82 @@
 import json
 import os
 import shutil
+from contextlib import contextmanager
+from typing import Any, Optional
 
 import pytest
 
-from webdriver_recorder.browser import XPathWithSubstringLocator
+from webdriver_recorder.browser import XPathWithSubstringLocator, Chrome
 from webdriver_recorder.plugin import lettergen
 
 # Enables testing failure cases in plugin logic by dynamically generating
 # and running plugin tests.
 pytest_plugins = ['pytester']
 
-@pytest.fixture(autouse=True)
-def load_page(browser, local_html_path):
-    """
-    Opens the local testing example html without recording any snapshots (in order to keep the `pngs` clean by default).
-    """
-    with browser.autocapture_off():  # Don't generate any PNGs as part of the autoused fixture.
-        browser.get(f'file://{local_html_path}')
 
-def test_happy_chrome(chrome):
+@contextmanager
+def preserve_environment_variable(var_name, new_value: Optional[Any] = None):
     """
-    A simple test case to ensure the fixture itself works; the heavy lifting is all tested in the browser tests.
+    Preserves the state of an environment variable, re-setting it
+    when the context exits.
+
+    This seems verbose, but it's that way on purpose. MacOS comes with a
+    vulnerability to a memory leak when setting environment variables without
+    unsetting them first. The python docs warn about this, but also state that this
+    is the recommended way to interact with environment variables, so this will
+    explicitly unset variables before setting them to avoid this (probably not
+    high-risk) leak vector.
     """
-    _test_happy_case(chrome)
+    existing_value = os.environ.get(var_name)
+    if existing_value is not None:
+        # Explicitly unset to avoid a memory leak on MacOS
+        del os.environ[var_name]
+    if new_value is not None:
+        os.environ[var_name] = new_value
+    yield
+    if var_name in os.environ:
+        del os.environ[var_name]
+    if existing_value is not None:
+        os.environ[var_name] = existing_value
 
 
-def test_browser_error_failure_reporting(chrome, testdir, local_html_path, report_dir):
+@pytest.mark.parametrize('env_var, fixture, fixture_value', [
+    ('NO_HEADLESS', 'disable_headless', True),
+    ('W3C_COMPLY', 'disable_w3c', False)
+])
+@pytest.mark.parametrize('env_value, expected_results', [
+    ("1", dict(passed=1)),
+    (None, dict(failed=1)),
+    ("", dict(failed=1)),
+])
+def test_env_var_fixtures(env_var, fixture, env_value, fixture_value,
+                          expected_results, testdir):
+    with preserve_environment_variable(env_var, new_value=env_value):
+        testdir.makepyfile(
+            f"""
+            def test_fixture({fixture}):
+                assert {fixture} is {fixture_value}
+            """
+        )
+        result = testdir.runpytest()
+        result.assert_outcomes(**expected_results)
+
+
+def test_incorrect_chromedriver_bin(testdir):
+    with preserve_environment_variable('CHROME_BIN', '/does/not/exist'):
+        with preserve_environment_variable('NO_HEADLESS'):
+            testdir.makepyfile(
+                f"""
+                def test_chromedriver_bin(browser):
+                    browser.get('https://www.uw.edu')
+                """
+            )
+            result = testdir.runpytest()
+            result.assert_outcomes(error=1)
+
+
+
+def test_browser_error_failure_reporting(testdir, local_html_path, report_dir):
     """
     This uses the pytester plugin to execute ad-hoc tests in a new testing instance. This is the only way to test
     the logic of fixtures after their included `yield` statement, and is what the pytester plugin was designed to do.
@@ -54,7 +104,7 @@ def test_browser_error_failure_reporting(chrome, testdir, local_html_path, repor
     assert result['failure']['message'] == 'forced failure'
 
 
-def test_failure_reporting(chrome, testdir, local_html_path, report_dir):
+def test_failure_reporting(testdir, local_html_path, report_dir):
     """
     Similar to test_browser_error_failure_reporting, but with a generic AssertionError. This is what we would expect
     to see under most failure circumstances.
@@ -80,7 +130,7 @@ def test_failure_reporting(chrome, testdir, local_html_path, report_dir):
     assert 'AssertionError' in result['failure']['message']
 
 
-def test_report_generator(browser, report_generator, testdir, local_html_path):
+def test_report_generator(testdir, local_html_path):
     """
     While the report generator could be tested by invoking directly, this test adds an extra layer of ensuring
     the correct default behavior is to write the report even if the test itself fails.
@@ -102,6 +152,7 @@ def test_report_generator(browser, report_generator, testdir, local_html_path):
         )
         result = testdir.runpytest('--report-dir', report_dir)
         expected_filename = os.path.join(report_dir, 'index.html')
+        result.assert_outcomes(passed=1)
         assert os.path.exists(expected_filename)
     finally:
         shutil.rmtree(report_dir)
@@ -116,15 +167,20 @@ def test_lettergen():
 @pytest.mark.xfail(reason="The remote fixture is hard to test because it requires a locally running selenium instance, "
                           "which itself requires extra dependencies and configuration. "
                           "As long as we don't have anything relying on this, it's probably more trouble than "
-                          "it's worth to setup.")
-def test_happy_remote_chrome(remote_chrome):
-    _test_happy_case(remote_chrome)
+                          "it's worth to set up.")
+def test_happy_remote_chrome():
+    assert False
 
 
-# The underscore here keeps pytest from executing this as a test itself.
-def _test_happy_case(browser):
-    browser.wait_for(XPathWithSubstringLocator(tag='button', displayed_substring='update'))
-    browser.send_inputs('boundless')
-    browser.click_button('update')
-    browser.wait_for(XPathWithSubstringLocator(tag='p', displayed_substring='boundless'))
-    assert len(browser.pngs) == 3
+def test_happy_case(testdir, local_html_path):
+    testdir.makepyfile(
+        f"""
+        def test_happy_case(browser):
+            browser.get({local_html_path})
+            browser.wait_for(XPathWithSubstringLocator(tag='button', displayed_substring='update'))
+            browser.send_inputs('boundless')
+            browser.click_button('update')
+            browser.wait_for(XPathWithSubstringLocator(tag='p', displayed_substring='boundless'))
+            assert len(browser.pngs) == 3
+        """
+    )

--- a/webdriver_recorder/browser.py
+++ b/webdriver_recorder/browser.py
@@ -1,7 +1,6 @@
 """BrowserRecorder class for recording snapshots between waits.
 """
 import json
-import os
 import pprint
 import time
 from contextlib import contextmanager
@@ -302,15 +301,7 @@ def _xpath_contains(node, substring):
 
 
 class Chrome(BrowserRecorder, webdriver.Chrome):
-    def __init__(self, *args, options=None, **kwargs):
-        options = options or webdriver.ChromeOptions()
-        if 'CHROME_BIN' in os.environ:
-            options.binary_location = os.environ['CHROME_BIN']
-        if 'NO_HEADLESS' not in os.environ:
-            options.headless = True    # default to what works in CI.
-        if 'W3C_COMPLY' not in os.environ:
-            options.add_experimental_option('w3c', False)
-        super().__init__(*args, options=options, **kwargs)
+    pass
 
 
 class Remote(BrowserRecorder, webdriver.Remote):


### PR DESCRIPTION
- Refactors to use a chrome_options fixture instead of configuring options in the class; this way others can extend
  those options canonically.
- Adds `disable_w3c` fixture that can be overridden in lieu of using the W3C_COMPLY environment variable.
- Adds `disable_headless` fixture that can be overridden in lieu of using the NO_HEADLESS environment variable
- Adds `chromedriver_bin` fixture that can be overridden in lieu of using the CHROME_BIN environment variable.
- Adds tests for new fixtures, and fixes tests so that the browser tests always run inside the pytester context.

---

Note that this doesn't change existing behavior for dependents, it only exposes these options as fixtures. The extra `options=options` wiring needed in _these_ tests are because we're testing the pytest plugin itself, so there's an extra meta-layer that has to be dealt with. (Just wanted to make it clear that anything depending on this should have no issues pulling in this upgrade.)