### PR TITLE
Bugfixes to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,13 @@ on:
       patch-level:
         default: prerelease
         required: true
-        description: "either an explicit version or a hint
-                      to poetry from patch|minor|major|prerelease;"
+        description: "VERSION INSTRUCTION. (Can be an explicit version or a hint
+                      to poetry from patch|minor|major|prerelease)"
       dry-run:
         required: true
         default: 'true'
-        description: Change this to 'false' if you are sure you want to release!
+        description: >
+          DRY RUN? (Change this to 'false' if you are sure you want to release!)
 
 env:
   workflow_url: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           artifacts: ./webdriver-report
           token: ${{ github.token }}
+          tag: ${{ steps.configure.outputs.release-version }}
 
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,21 @@ jobs:
           fi
 
       - uses: actions/checkout@v2
+
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
           service_account_key: ${{ secrets.GCR_TOKEN }}
           export_default_credentials: true
         uses: google-github-actions/setup-gcloud@master
+
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - uses: abatilo/actions-poetry@v2.1.2
+        -
       - uses: nanasess/setup-chromedriver@v1.0.5
+
       - run: |
           poetry version ${{ github.event.inputs.patch-level || 'prerelease' }}
           set -x
@@ -58,6 +63,7 @@ jobs:
           poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
           echo "SLACK_CANVAS_ID=${{ github.event_name }}/$VERSION" >> $GITHUB_ENV
         id: configure
+
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         with:
           command: create-canvas
@@ -96,8 +102,10 @@ jobs:
             <${{ env.workflow_url }} | Workflow> triggered by ${{ github.actor }}
             from a ${{ github.event_name }} at
             <${{ env.commit_url }} | commit ${{ steps.configure.outputs.short-sha }}>
+
       - run: poetry run tox
         id: run-tests
+
       - if: always()
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         env:
@@ -107,6 +115,7 @@ jobs:
           command: update-workflow
           step-id: run-tests, release
           step-status: ${{ env.test-status }}, ${{ env.release-status }}
+
       - uses: EndBug/add-and-commit@v7.2.1
         env:
           commit-message: >
@@ -124,6 +133,7 @@ jobs:
         with:
           artifacts: ./webdriver-report
           token: ${{ github.token }}
+
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         env:
           release_version: ${{ steps.configure.outputs.release-version }}
@@ -134,9 +144,11 @@ jobs:
           description: >
             ${{ env.action_desc }} release
             <${{ env.release_url }} | ${{ env.release_version }}>
+
       - run: poetry publish
         if: env.dry_run != 'true'
         id: publish-release
+
       - if: always()
         env:
           status: ${{ steps.publish-release.outcome != 'failure' && 'succeeded' || 'failed' }}
@@ -146,12 +158,14 @@ jobs:
           step-status: ${{ env.status }}
           workflow-status: ${{ env.status }}
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
+
       - if: always()
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         with:
           command: remove-step
           step-id: '*'
           step-status: succeeded
+
       - if: always()
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,7 @@ jobs:
           then
             echo 'dry_run=false' >> $GITHUB_ENV
           fi
-      - if: >
-          (github.event_name == 'push'
-          && github.ref == 'refs/heads/test-release-workflow')
-          || github.event.inputs.dry-run == 'true'
-        run: echo 'dry_run=true' >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
@@ -121,13 +117,12 @@ jobs:
           push: ${{ env.dry_run == 'true' && 'false' || 'true' }}
           default_author: github_actor
           message: ${{ env.commit-message }}
-          tag: ${{ steps.configure.outputs.release-version }}
+
       - uses: ncipollo/release-action@v1.8.6
         if: env.dry_run != 'true'
         id: create-release
         with:
           artifacts: ./webdriver-report
-          tag: ${{ steps.configure.outputs.release-version }}
           token: ${{ github.token }}
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,12 +129,16 @@ jobs:
           default_author: github_actor
           message: ${{ env.commit-message }}
 
+      - id: version-commit
+        run: echo "::set-output name=sha::$(git rev-parse HEAD)"
+        shell: bash
+
       - uses: ncipollo/release-action@v1.8.6
         if: env.dry_run != 'true'
         id: create-release
         with:
           token: ${{ github.token }}
-          commit: ${{ github.sha }}
+          commit: ${{ steps.version-commit.outputs.sha }}
           tag: ${{ steps.configure.outputs.release-version }}
 
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           allowUpdates: true
           artifacts: ./webdriver-report
           tag: ${{ steps.configure.outputs.release-version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main
         env:
           release_version: ${{ steps.configure.outputs.release-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,11 +122,10 @@ jobs:
           default_author: github_actor
           message: ${{ env.commit-message }}
           tag: ${{ steps.configure.outputs.release-version }}
-      - uses: actions/create-release@v1.1.4
+      - uses: ncipollo/release-action@v1.8.6
         if: env.dry_run != 'true'
         id: create-release
         with:
-          allowUpdates: true
           artifacts: ./webdriver-report
           tag: ${{ steps.configure.outputs.release-version }}
           token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,13 +111,13 @@ jobs:
           command: update-workflow
           step-id: run-tests, release
           step-status: ${{ env.test-status }}, ${{ env.release-status }}
-      - uses: EndBug/add-and-commit@v7
+      - uses: EndBug/add-and-commit@v7.2.1
         env:
           commit-message: >
             Tag new version ${{ steps.configure.outputs.release-version }}
         with:
           add: pyproject.toml poetry.lock
-          pull-strategy: NO-PULL
+          pull_strategy: NO-PULL
           push: ${{ env.dry_run == 'true' && 'false' || 'true' }}
           default_author: github_actor
           message: ${{ env.commit-message }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: 3.7
 
       - uses: abatilo/actions-poetry@v2.1.2
-        -
+
       - uses: nanasess/setup-chromedriver@v1.0.5
 
       - run: |
@@ -117,9 +117,11 @@ jobs:
           step-status: ${{ env.test-status }}, ${{ env.release-status }}
 
       - uses: EndBug/add-and-commit@v7.2.1
+        id: update-project-version
         env:
           commit-message: >
-            Tag new version ${{ steps.configure.outputs.release-version }}
+            Update pyproject.toml version to
+            ${{ steps.configure.outputs.release-version }}
         with:
           add: pyproject.toml poetry.lock
           pull_strategy: NO-PULL
@@ -151,7 +153,7 @@ jobs:
 
       - if: always()
         env:
-          status: ${{ steps.publish-release.outcome != 'failure' && 'succeeded' || 'failed' }}
+          status: ${{ job.status != 'failure' && 'succeeded' || 'failed' }}
         with:
           command: update-workflow
           step-id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
             ${{ env.action_desc }} release
             <${{ env.release_url }} | ${{ env.release_version }}>
 
-      - run: poetry publish
+      - run: poetry publish --build
         if: env.dry_run != 'true'
         id: publish-release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
         id: create-release
         with:
           token: ${{ github.token }}
+          commit: ${{ github.sha }}
           tag: ${{ steps.configure.outputs.release-version }}
 
       - uses: UWIT-IAM/actions/update-slack-workflow-canvas@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,6 @@ jobs:
         if: env.dry_run != 'true'
         id: create-release
         with:
-          artifacts: ./webdriver-report
           token: ${{ github.token }}
           tag: ${{ steps.configure.outputs.release-version }}
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,29 @@ with the Chrome binary.
 
 ### Releasing Changes
 
+To release a change out in the wild, you should use
+the Github Actions UI.
+
+1. Visit the [release workflow UI]
+2. Click on `Run Workflow`
+3. Select the branch you want to release.
+4. Leave the `dry-run` option set to `true`.
+5. Click `Run`
+
+Wait for the dry run to complete in the `#iam-bots` slack channel.
+
+If the dry run succeeded, validate the generated version number is what you expected 
+and, if so, repeat steps 1–3 above, but change the `dry-run` option to `false`.
+
+**This means you can create prereleases for any branch you're working on to test it 
+with another package, before merging into `master`!**
+
+
+#### Manual Release
+
+If you want to release something without the use of
+Github Actions, you can follow these steps:
+
 Release changes using poetry: 
 
 - `poetry update`
@@ -201,7 +224,7 @@ Release changes using poetry:
 - `poetry publish --build`
   - username: `uw-it-iam`
   - password: Ask @tomthorogood!
-
+  
 ### Testing Changes
 
 `poetry run tox` (or simply `tox` if you are already in the `poetry shell`)
@@ -211,3 +234,6 @@ Release changes using poetry:
 - (Recommended) Run [black](https://github.com/psf/black) -- this will
   be automated in the future: `black webdriver_recorder/*.py tests/*.py`
 - Run validations before submitting using `tox`; this will prevent unnecessary churn in your pull request.
+
+
+[release workflow ui]: https://github.com/UWIT-IAM/webdriver-recorder/actions/workflows/release.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-webdriver-recorder"
-version = "4.0.0-rc.7"
+version = "4.0.0-rc.8"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]
 license = "Apache Software License 3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+name = "uw-webdriver-recorder"
 version = "4.0.0-rc.3"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-webdriver-recorder"
-version = "4.0.0-rc.3"
+version = "4.0.0-rc.4"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]
 license = "Apache Software License 3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-webdriver-recorder"
-version = "4.0.0-rc.6"
+version = "4.0.0-rc.7"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]
 license = "Apache Software License 3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "webdriver-recorder"
+name = "uw-webdriver-recorder"
 version = "4.0.0-rc.2"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-webdriver-recorder"
-version = "4.0.0-rc.5"
+version = "4.0.0-rc.6"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]
 license = "Apache Software License 3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-webdriver-recorder"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 description = "A pytest plugin for recording screenshots of selenium interactions, with other convenient features too."
 authors = ["Tom Thorogood <goodtom@uw.edu>"]
 license = "Apache Software License 3.0"


### PR DESCRIPTION
Because dry runs only get us so far. For everything else there are lots of little bugfixes.

This doesn't change any of the actual code, just the release workflow. When this merges into `master`, it _should_ create a `4.0.0-rc.9` version. (The other rc's were generated by me running the manual workflow).

The commit messages tell you what's going on. There are a lot of them, but not really a lot of lines of config changed.

You'll notice that the `Update pyproject.toml...` commits appear in this pull request, those artifacts _only_ appear because I ran the manual workflow; opening a pull request itself does not usually trigger a prerelelase. (Maybe that's a future feature possibility, but this is not what I'm supposed to be working on...)

Here is what the manual workflow looks like:

![Screen Shot 2021-06-16 at 1 26 16 PM](https://user-images.githubusercontent.com/1092941/122288076-83704c80-cea6-11eb-832f-65257d4c46a1.png)

To learn more about it, see the [updates](https://github.com/UWIT-IAM/webdriver-recorder/pull/24/commits/2fc893ae480e6618e553d020bcd37cd100671511) to the `Releasing Changes` section of the README.