### PR TITLE
[GH-45] - Update references from "master" to "main" branches 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release new version of webdriver-recorder
 on:
   push:
     branches:
-      - master
+      - main
       - test-release-workflow
   workflow_dispatch:
     inputs:
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [[ -n "${{ github.event.inputs.dry-run }}" ]]; then
             echo 'dry_run=${{ github.event.inputs.dry-run }}' >> $GITHUB_ENV
-          elif [[ "$(basename ${{ github.ref }})" == "master" ]]; then
+          elif [[ "$(basename ${{ github.ref }})" == "main" ]]; then
             echo 'dry_run=false' >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
Our action is still referring to the `master` branch instead of `main`. This PR updateds the [release.yml](https://github.com/UWIT-IAM/webdriver-recorder/blob/main/.github/workflows/release.yml#L33) workflow to point to `main` instead.